### PR TITLE
fix: remove `color` prop leftover from create-react-native-library

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -9,7 +9,6 @@ export default function App() {
       <AudioGraphView
         accessible
         accessibilityLabel={'Inner audio graph view'}
-        color="#32a852"
         style={styles.box}
         title={'Test graph title'}
         summary={'Text graph summary'}

--- a/ios/AudioGraphViewManager.m
+++ b/ios/AudioGraphViewManager.m
@@ -2,8 +2,6 @@
 
 @interface RCT_EXTERN_MODULE(AudioGraphViewManager, RCTViewManager)
 
-RCT_EXPORT_VIEW_PROPERTY(color, NSString)
-
 RCT_EXPORT_VIEW_PROPERTY(title, NSString)
 RCT_EXPORT_VIEW_PROPERTY(summary, NSString)
 RCT_EXPORT_VIEW_PROPERTY(xTitle, NSString)

--- a/ios/AudioGraphViewManager.swift
+++ b/ios/AudioGraphViewManager.swift
@@ -12,28 +12,6 @@ class AudioGraphViewManager: RCTViewManager {
 
 class AudioGraphView : UIView, AXChart {
 
-  @objc var color: String = "" {
-    didSet {
-      self.backgroundColor = hexStringToUIColor(hexColor: color)
-    }
-  }
-
-  func hexStringToUIColor(hexColor: String) -> UIColor {
-    let stringScanner = Scanner(string: hexColor)
-
-    if(hexColor.hasPrefix("#")) {
-      stringScanner.scanLocation = 1
-    }
-    var color: UInt32 = 0
-    stringScanner.scanHexInt32(&color)
-
-    let r = CGFloat(Int(color >> 16) & 0x000000FF)
-    let g = CGFloat(Int(color >> 8) & 0x000000FF)
-    let b = CGFloat(Int(color) & 0x000000FF)
-
-    return UIColor(red: r / 255.0, green: g / 255.0, blue: b / 255.0, alpha: 1)
-  }
-    
     // AXChart implementation
     @objc var title: String = ""
     @objc var summary: String = ""

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,7 +13,6 @@ const LINKING_ERROR =
   '- You are not using Expo Go\n';
 
 interface AudioGraphProps extends ViewProps {
-  color: string;
   style: ViewStyle;
 
   title: string;


### PR DESCRIPTION
BREAKING CHANGE: prop should never have been supported

closes #1 